### PR TITLE
nloop_all

### DIFF
--- a/getinp.f90
+++ b/getinp.f90
@@ -37,6 +37,7 @@ subroutine getinp()
   writeout = 10
   maxit = 20
   nloop = 0
+  nloop_all = 0
   movefrac = 0.05
   movebadrandom = .false.
   precision = 1.d-2
@@ -83,7 +84,11 @@ subroutine getinp()
     else if(keyword(i,1).eq.'nloop') then
       read(keyword(i,2),*,iostat=ioerr) nloop
       if ( ioerr /= 0 ) exit
-      write(*,*) ' User defined numer of GENCAN loops: ', nloop
+      write(*,*) ' User defined number of GENCAN loops: ', nloop
+    else if(keyword(i,1).eq.'nloop_all') then
+      read(keyword(i,2),*,iostat=ioerr) nloop_all
+      if ( ioerr /= 0 ) exit
+      write(*,*) ' User defined diferential number of GENCAN loops for All-together packing: ', nloop_all
     else if(keyword(i,1).eq.'discale') then
       read(keyword(i,2),*,iostat=ioerr) discale
       if ( ioerr /= 0 ) exit
@@ -156,6 +161,7 @@ subroutine getinp()
              keyword(i,1) /= 'restart_from' .and. &
              keyword(i,1) /= 'restart_to' .and. &
              keyword(i,1) /= 'nloop' .and. &
+             keyword(i,1) /= 'nloop_all' .and. &
              keyword(i,1) /= 'writeout' .and. &
              keyword(i,1) /= 'writebad' .and. &
              keyword(i,1) /= 'check' .and. &
@@ -410,6 +416,7 @@ subroutine getinp()
                '(',natoms(itype),' atoms)'
   end do
   if(nloop.eq.0) nloop = 200*ntype
+  if(nloop_all.eq.0) nloop_all = nloop
       
   ! Reading the restrictions that were set
 

--- a/initial.f90
+++ b/initial.f90
@@ -137,23 +137,9 @@ subroutine initial(n,x)
 
   ! Initialize cartesian coordinate array for the first time
 
-  if(fix) then
-    icart = 0
-    do iftype = ntype + 1, ntfix
-      idfatom = idfirst(iftype) - 1
-      do ifatom = 1, natoms(iftype)
-        idfatom = idfatom + 1
-        icart = icart + 1
-        xcart(icart,1) = coor(idfatom,1)
-        xcart(icart,2) = coor(idfatom,2)
-        xcart(icart,3) = coor(idfatom,3)
-        fixedatom(icart) = .true.
-      end do
-    end do
-  end if
   ilubar = 0
   ilugan = ntotmol*3
-  icart = natfix
+  icart = 0
   do itype = 1, ntype
     do imol = 1, nmols(itype)
       xbar = x(ilubar+1)
@@ -174,6 +160,20 @@ subroutine initial(n,x)
       end do
     end do
   end do
+  if(fix) then
+    icart = ntotat - natfix
+    do iftype = ntype + 1, ntfix
+      idfatom = idfirst(iftype) - 1
+      do ifatom = 1, natoms(iftype)
+        idfatom = idfatom + 1
+        icart = icart + 1
+        xcart(icart,1) = coor(idfatom,1)
+        xcart(icart,2) = coor(idfatom,2)
+        xcart(icart,3) = coor(idfatom,3)
+        fixedatom(icart) = .true.
+      end do
+    end do
+  end if
 
   ! Use the largest radius as the reference for binning the box
 
@@ -232,7 +232,7 @@ subroutine initial(n,x)
       write(*,*) '        at all. '
       write(*,*) '        Please check the spatial constraints and' 
       write(*,*) '        try again.'
-      if ( i .ge. ntype ) then
+      if ( i .ge. ntype+1 ) then
       end if
         write(*,*) ' >The maximum number of cycles (',nloop,') was achieved.' 
         write(*,*) '  You may try increasing it with the',' nloop keyword, as in: nloop 1000 '
@@ -295,7 +295,7 @@ subroutine initial(n,x)
 
   write(*,*) ' Add fixed molecules to permanent arrays... '
   if(fix) then
-    icart = 0
+    icart = ntotat - natfix
     do iftype = ntype + 1, ntfix
       idfatom = idfirst(iftype) - 1
       do ifatom = 1, natoms(iftype)
@@ -325,7 +325,7 @@ subroutine initial(n,x)
     cmzmax(itype) = -1.d20
   end do
 
-  icart = natfix
+  icart = 0
   do itype = 1, ntype
     do imol = 1, nmols(itype)
       cmx = 0.d0

--- a/initial.f90
+++ b/initial.f90
@@ -137,9 +137,23 @@ subroutine initial(n,x)
 
   ! Initialize cartesian coordinate array for the first time
 
+  if(fix) then
+    icart = 0
+    do iftype = ntype + 1, ntfix
+      idfatom = idfirst(iftype) - 1
+      do ifatom = 1, natoms(iftype)
+        idfatom = idfatom + 1
+        icart = icart + 1
+        xcart(icart,1) = coor(idfatom,1)
+        xcart(icart,2) = coor(idfatom,2)
+        xcart(icart,3) = coor(idfatom,3)
+        fixedatom(icart) = .true.
+      end do
+    end do
+  end if
   ilubar = 0
   ilugan = ntotmol*3
-  icart = 0
+  icart = natfix
   do itype = 1, ntype
     do imol = 1, nmols(itype)
       xbar = x(ilubar+1)
@@ -160,20 +174,6 @@ subroutine initial(n,x)
       end do
     end do
   end do
-  if(fix) then
-    icart = ntotat - natfix
-    do iftype = ntype + 1, ntfix
-      idfatom = idfirst(iftype) - 1
-      do ifatom = 1, natoms(iftype)
-        idfatom = idfatom + 1
-        icart = icart + 1
-        xcart(icart,1) = coor(idfatom,1)
-        xcart(icart,2) = coor(idfatom,2)
-        xcart(icart,3) = coor(idfatom,3)
-        fixedatom(icart) = .true.
-      end do
-    end do
-  end if
 
   ! Use the largest radius as the reference for binning the box
 
@@ -206,13 +206,13 @@ subroutine initial(n,x)
     i = 0
     hasbad = .true.
     call computef(n,x,fx)
-    do while( frest > precision .and. i.le. (nloop/10-1) .and. hasbad)
+    do while( frest > precision .and. i.le. (ntype+1) .and. hasbad)
       i = i + 1 
       write(*,prog1_line)
       call pgencan(n,x,fx)
       call computef(n,x,fx)
       if(frest > precision) then 
-        write(*,"( a,i6,a,i6 )")'  Fixing bad orientations ... ', i,' of ',nloop/10
+        write(*,"( a,i6,a,i6 )")'  Fixing bad orientations ... ', i,' of ',ntype+2
         movebadprint = .true.
         call movebad(n,x,fx,movebadprint) 
       end if
@@ -232,7 +232,7 @@ subroutine initial(n,x)
       write(*,*) '        at all. '
       write(*,*) '        Please check the spatial constraints and' 
       write(*,*) '        try again.'
-      if ( i .ge. nloop/10-1 ) then
+      if ( i .ge. ntype ) then
       end if
         write(*,*) ' >The maximum number of cycles (',nloop,') was achieved.' 
         write(*,*) '  You may try increasing it with the',' nloop keyword, as in: nloop 1000 '
@@ -295,7 +295,7 @@ subroutine initial(n,x)
 
   write(*,*) ' Add fixed molecules to permanent arrays... '
   if(fix) then
-    icart = ntotat - natfix
+    icart = 0
     do iftype = ntype + 1, ntfix
       idfatom = idfirst(iftype) - 1
       do ifatom = 1, natoms(iftype)
@@ -325,7 +325,7 @@ subroutine initial(n,x)
     cmzmax(itype) = -1.d20
   end do
 
-  icart = 0
+  icart = natfix
   do itype = 1, ntype
     do imol = 1, nmols(itype)
       cmx = 0.d0
@@ -562,13 +562,13 @@ subroutine initial(n,x)
     i = 0
     call computef(n,x,fx)
     hasbad = .true.
-    do while( frest > precision .and. i <= (nloop/10-1) .and. hasbad)
+    do while( frest > precision .and. i <= (ntype+1) .and. hasbad)
       i = i + 1 
       write(*,prog1_line)
       call pgencan(n,x,fx)
       call computef(n,x,fx)
       if(frest > precision) then
-        write(*,"( a,i6,a,i6 )")'  Fixing bad orientations ... ', i,' of ',nloop/10
+        write(*,"( a,i6,a,i6 )")'  Fixing bad orientations ... ', i,' of ',ntype+2
         movebadprint = .true.
         call movebad(n,x,fx,movebadprint)
       end if

--- a/input.f90
+++ b/input.f90
@@ -15,6 +15,7 @@ module input
   integer :: nrest
   integer :: seed
   integer :: nloop
+  integer :: nloop_all
   integer :: writeout
   integer :: ntfix
   integer :: ntcon(9) 

--- a/packmol.f90
+++ b/packmol.f90
@@ -101,104 +101,6 @@ program packmol
      
   write(*,*) ' Total number of atoms: ', ntotat
 
-  ! Setting the vector that contains the default tolerance
-
-  do i = 1, ntotat
-    radius(i) = dism/2.d0
-  end do
-
-  ! Setting the radius defined for atoms of each molecule, 
-  ! but not atom-specific, first
-
-  icart = 0
-  do itype = 1, ntype
-    iline = linestrut(itype,1)
-    iline_atoms = 0 
-    do while( iline <= linestrut(itype,2) )
-      if ( keyword(iline,1) == "atoms" ) then
-        iline_atoms = iline
-        iline = iline + 1
-        cycle
-      end if
-      if ( keyword(iline,1) == "end" .and. &    
-           keyword(iline,2) == "atoms" ) then
-        iline_atoms = 0  
-        iline = iline + 1
-        cycle
-      end if
-      if ( iline_atoms == 0 ) then
-        if ( keyword(iline,1) == "radius" ) then
-          read(keyword(iline,2),*,iostat=ioerr) rad
-          if ( ioerr /= 0 ) then
-            write(*,*) ' ERROR: Could not read radius from keyword. '
-            stop
-          end if
-          iicart = icart
-          do imol = 1, nmols(itype)
-            do iatom = 1, natoms(itype)
-              iicart = iicart + 1
-              radius(iicart) = rad 
-            end do
-          end do
-        end if
-      end if
-      iline = iline + 1
-    end do
-    icart = icart + nmols(itype)*natoms(itype)
-  end do
- 
-  ! If some radius was defined using atom-specific definitions, overwrite
-  ! the general radius defined for the molecule
-
-  icart = 0
-  do itype = 1, ntype
-    iline = linestrut(itype,1)
-    iline_atoms = 0 
-    do while( iline <= linestrut(itype,2) )
-      if ( keyword(iline,1) == "atoms" ) then
-        iline_atoms = iline
-        iline = iline + 1
-        cycle
-      end if
-      if ( keyword(iline,1) == "end" .and. &    
-           keyword(iline,2) == "atoms" ) then
-        iline_atoms = 0  
-        iline = iline + 1
-        cycle
-      end if
-      if ( iline_atoms /= 0 ) then
-        if ( keyword(iline,1) == "radius" ) then
-          read(keyword(iline,2),*,iostat=ioerr) rad
-          if ( ioerr /= 0 ) then
-            write(*,*) ' ERROR: Could not read radius from keyword. '
-            stop
-          end if
-          ival = 2
-          do
-            read(keyword(iline_atoms,ival),*,iostat=ioerr) iat
-            if ( ioerr /= 0 ) exit
-            if ( iat > natoms(itype) ) then
-              write(*,*) ' ERROR: atom selection with index greater than number of '
-              write(*,*) '        atoms in structure ', itype
-              stop
-            end if
-            radius(icart+iat) = rad
-            ival = ival + 1
-          end do
-        end if
-      end if
-      iline = iline + 1
-    end do
-    iicart = icart
-    icart = icart + natoms(itype)
-    do imol = 2, nmols(itype)
-      do iatom = 1, natoms(itype)
-        icart = icart + 1
-        radius(icart) = radius(iicart+iatom)
-      end do
-    end do
-  end do
-
   ! Put fixed molecules in the specified position
 
   do itype = 1, ntype
@@ -263,8 +165,8 @@ program packmol
   ntemp = 0
   do itype = 1, ntype
 
-  ! input_itype and fixedoninput vectors are used only to preserve the
-  ! order of input in the output files
+    ! input_itype and fixedoninput vectors are used only to preserve the
+    ! order of input in the output files
 
     input_itype(itype) = itype
     if(fixed(itype)) then
@@ -365,7 +267,7 @@ program packmol
 
   ! Setting the array that contains the restrictions per atom
 
-  icart = natfix
+  icart = 0
   do itype = 1, ntype
     rests = .false.
     do imol = 1, nmols(itype)
@@ -499,6 +401,104 @@ program packmol
     end do
   end do
  
+  ! Setting the vector that contains the default tolerance
+
+  do i = 1, ntotat
+    radius(i) = dism/2.d0
+  end do
+
+  ! Setting the radius defined for atoms of each molecule, 
+  ! but not atom-specific, first
+
+  icart = 0
+  do itype = 1, ntfix
+    iline = linestrut(itype,1)
+    iline_atoms = 0 
+    do while( iline <= linestrut(itype,2) )
+      if ( keyword(iline,1) == "atoms" ) then
+        iline_atoms = iline
+        iline = iline + 1
+        cycle
+      end if
+      if ( keyword(iline,1) == "end" .and. &    
+           keyword(iline,2) == "atoms" ) then
+        iline_atoms = 0  
+        iline = iline + 1
+        cycle
+      end if
+      if ( iline_atoms == 0 ) then
+        if ( keyword(iline,1) == "radius" ) then
+          read(keyword(iline,2),*,iostat=ioerr) rad
+          if ( ioerr /= 0 ) then
+            write(*,*) ' ERROR: Could not read radius from keyword. '
+            stop
+          end if
+          iicart = icart
+          do imol = 1, nmols(itype)
+            do iatom = 1, natoms(itype)
+              iicart = iicart + 1
+              radius(iicart) = rad 
+            end do
+          end do
+        end if
+      end if
+      iline = iline + 1
+    end do
+    icart = icart + nmols(itype)*natoms(itype)
+  end do
+ 
+  ! If some radius was defined using atom-specific definitions, overwrite
+  ! the general radius defined for the molecule
+
+  icart = 0
+  do itype = 1, ntfix
+    iline = linestrut(itype,1)
+    iline_atoms = 0 
+    do while( iline <= linestrut(itype,2) )
+      if ( keyword(iline,1) == "atoms" ) then
+        iline_atoms = iline
+        iline = iline + 1
+        cycle
+      end if
+      if ( keyword(iline,1) == "end" .and. &    
+           keyword(iline,2) == "atoms" ) then
+        iline_atoms = 0  
+        iline = iline + 1
+        cycle
+      end if
+      if ( iline_atoms /= 0 ) then
+        if ( keyword(iline,1) == "radius" ) then
+          read(keyword(iline,2),*,iostat=ioerr) rad
+          if ( ioerr /= 0 ) then
+            write(*,*) ' ERROR: Could not read radius from keyword. '
+            stop
+          end if
+          ival = 2
+          do
+            read(keyword(iline_atoms,ival),*,iostat=ioerr) iat
+            if ( ioerr /= 0 ) exit
+            if ( iat > natoms(itype) ) then
+              write(*,*) ' ERROR: atom selection with index greater than number of '
+              write(*,*) '        atoms in structure ', itype
+              stop
+            end if
+            radius(icart+iat) = rad
+            ival = ival + 1
+          end do
+        end if
+      end if
+      iline = iline + 1
+    end do
+    iicart = icart
+    icart = icart + natoms(itype)
+    do imol = 2, nmols(itype)
+      do iatom = 1, natoms(itype)
+        icart = icart + 1
+        radius(icart) = radius(iicart+iatom)
+      end do
+    end do
+  end do
+
   ! If there are no variables (only fixed molecules, stop)
 
   if(n.eq.0) then

--- a/packmol.f90
+++ b/packmol.f90
@@ -101,6 +101,104 @@ program packmol
      
   write(*,*) ' Total number of atoms: ', ntotat
 
+  ! Setting the vector that contains the default tolerance
+
+  do i = 1, ntotat
+    radius(i) = dism/2.d0
+  end do
+
+  ! Setting the radius defined for atoms of each molecule, 
+  ! but not atom-specific, first
+
+  icart = 0
+  do itype = 1, ntype
+    iline = linestrut(itype,1)
+    iline_atoms = 0 
+    do while( iline <= linestrut(itype,2) )
+      if ( keyword(iline,1) == "atoms" ) then
+        iline_atoms = iline
+        iline = iline + 1
+        cycle
+      end if
+      if ( keyword(iline,1) == "end" .and. &    
+           keyword(iline,2) == "atoms" ) then
+        iline_atoms = 0  
+        iline = iline + 1
+        cycle
+      end if
+      if ( iline_atoms == 0 ) then
+        if ( keyword(iline,1) == "radius" ) then
+          read(keyword(iline,2),*,iostat=ioerr) rad
+          if ( ioerr /= 0 ) then
+            write(*,*) ' ERROR: Could not read radius from keyword. '
+            stop
+          end if
+          iicart = icart
+          do imol = 1, nmols(itype)
+            do iatom = 1, natoms(itype)
+              iicart = iicart + 1
+              radius(iicart) = rad 
+            end do
+          end do
+        end if
+      end if
+      iline = iline + 1
+    end do
+    icart = icart + nmols(itype)*natoms(itype)
+  end do
+ 
+  ! If some radius was defined using atom-specific definitions, overwrite
+  ! the general radius defined for the molecule
+
+  icart = 0
+  do itype = 1, ntype
+    iline = linestrut(itype,1)
+    iline_atoms = 0 
+    do while( iline <= linestrut(itype,2) )
+      if ( keyword(iline,1) == "atoms" ) then
+        iline_atoms = iline
+        iline = iline + 1
+        cycle
+      end if
+      if ( keyword(iline,1) == "end" .and. &    
+           keyword(iline,2) == "atoms" ) then
+        iline_atoms = 0  
+        iline = iline + 1
+        cycle
+      end if
+      if ( iline_atoms /= 0 ) then
+        if ( keyword(iline,1) == "radius" ) then
+          read(keyword(iline,2),*,iostat=ioerr) rad
+          if ( ioerr /= 0 ) then
+            write(*,*) ' ERROR: Could not read radius from keyword. '
+            stop
+          end if
+          ival = 2
+          do
+            read(keyword(iline_atoms,ival),*,iostat=ioerr) iat
+            if ( ioerr /= 0 ) exit
+            if ( iat > natoms(itype) ) then
+              write(*,*) ' ERROR: atom selection with index greater than number of '
+              write(*,*) '        atoms in structure ', itype
+              stop
+            end if
+            radius(icart+iat) = rad
+            ival = ival + 1
+          end do
+        end if
+      end if
+      iline = iline + 1
+    end do
+    iicart = icart
+    icart = icart + natoms(itype)
+    do imol = 2, nmols(itype)
+      do iatom = 1, natoms(itype)
+        icart = icart + 1
+        radius(icart) = radius(iicart+iatom)
+      end do
+    end do
+  end do
+
   ! Put fixed molecules in the specified position
 
   do itype = 1, ntype
@@ -165,8 +263,8 @@ program packmol
   ntemp = 0
   do itype = 1, ntype
 
-    ! input_itype and fixedoninput vectors are used only to preserve the
-    ! order of input in the output files
+  ! input_itype and fixedoninput vectors are used only to preserve the
+  ! order of input in the output files
 
     input_itype(itype) = itype
     if(fixed(itype)) then
@@ -267,7 +365,7 @@ program packmol
 
   ! Setting the array that contains the restrictions per atom
 
-  icart = 0
+  icart = natfix
   do itype = 1, ntype
     rests = .false.
     do imol = 1, nmols(itype)
@@ -401,104 +499,6 @@ program packmol
     end do
   end do
  
-  ! Setting the vector that contains the default tolerance
-
-  do i = 1, ntotat
-    radius(i) = dism/2.d0
-  end do
-
-  ! Setting the radius defined for atoms of each molecule, 
-  ! but not atom-specific, first
-
-  icart = 0
-  do itype = 1, ntfix
-    iline = linestrut(itype,1)
-    iline_atoms = 0 
-    do while( iline <= linestrut(itype,2) )
-      if ( keyword(iline,1) == "atoms" ) then
-        iline_atoms = iline
-        iline = iline + 1
-        cycle
-      end if
-      if ( keyword(iline,1) == "end" .and. &    
-           keyword(iline,2) == "atoms" ) then
-        iline_atoms = 0  
-        iline = iline + 1
-        cycle
-      end if
-      if ( iline_atoms == 0 ) then
-        if ( keyword(iline,1) == "radius" ) then
-          read(keyword(iline,2),*,iostat=ioerr) rad
-          if ( ioerr /= 0 ) then
-            write(*,*) ' ERROR: Could not read radius from keyword. '
-            stop
-          end if
-          iicart = icart
-          do imol = 1, nmols(itype)
-            do iatom = 1, natoms(itype)
-              iicart = iicart + 1
-              radius(iicart) = rad 
-            end do
-          end do
-        end if
-      end if
-      iline = iline + 1
-    end do
-    icart = icart + nmols(itype)*natoms(itype)
-  end do
- 
-  ! If some radius was defined using atom-specific definitions, overwrite
-  ! the general radius defined for the molecule
-
-  icart = 0
-  do itype = 1, ntfix
-    iline = linestrut(itype,1)
-    iline_atoms = 0 
-    do while( iline <= linestrut(itype,2) )
-      if ( keyword(iline,1) == "atoms" ) then
-        iline_atoms = iline
-        iline = iline + 1
-        cycle
-      end if
-      if ( keyword(iline,1) == "end" .and. &    
-           keyword(iline,2) == "atoms" ) then
-        iline_atoms = 0  
-        iline = iline + 1
-        cycle
-      end if
-      if ( iline_atoms /= 0 ) then
-        if ( keyword(iline,1) == "radius" ) then
-          read(keyword(iline,2),*,iostat=ioerr) rad
-          if ( ioerr /= 0 ) then
-            write(*,*) ' ERROR: Could not read radius from keyword. '
-            stop
-          end if
-          ival = 2
-          do
-            read(keyword(iline_atoms,ival),*,iostat=ioerr) iat
-            if ( ioerr /= 0 ) exit
-            if ( iat > natoms(itype) ) then
-              write(*,*) ' ERROR: atom selection with index greater than number of '
-              write(*,*) '        atoms in structure ', itype
-              stop
-            end if
-            radius(icart+iat) = rad
-            ival = ival + 1
-          end do
-        end if
-      end if
-      iline = iline + 1
-    end do
-    iicart = icart
-    icart = icart + natoms(itype)
-    do imol = 2, nmols(itype)
-      do iatom = 1, natoms(itype)
-        icart = icart + 1
-        radius(icart) = radius(iicart+iatom)
-      end do
-    end do
-  end do
-
   ! If there are no variables (only fixed molecules, stop)
 
   if(n.eq.0) then
@@ -569,6 +569,7 @@ program packmol
       write(*,*) ' Packing molecules of type: ', input_itype(itype)
     else
       write(*,*) ' Packing all molecules together '
+      nloop = nloop_all
     end if
     write(*,hash3_line)
 


### PR DESCRIPTION
Added nloop_all for defining number of loops specifically for All-together packing. Changed the number of loops for fixing "bad molecules" from nloop/10-1 to ntypes+1, which allows to use a low number of nloops. In general this allows short individual molecule packing and a longer all-together process.