### PR TITLE
Adds missing installation target directory to CMake compile script

### DIFF
--- a/compile_cmake.sh
+++ b/compile_cmake.sh
@@ -7,6 +7,9 @@ export FFLAGS="-g -O2 -Wall"
 #export FFLAGS="-g -O2 -Wall -fbounds-check"
 #export FFLAGS="-g -O0 -Wall -fbounds-check"
 
+# Installation directory
+export target=$(pwd) # this installs packmol under bin/ in the present directory
+
 # Number of parallel processes in build
 export npar=4
 


### PR DESCRIPTION
In this PR, the missing target directory is added to the CMake compile script. Then, the packmol binary is installed under bin/ of the packmol root directory.