### PR TITLE
Update CMakeLists.txt for optimisation and cross-platform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-*.mod 
+build/
+*.mod
 *.o
 *.swp
 packmol

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,52 +1,57 @@
 cmake_minimum_required(VERSION 2.6)
 project(packmol Fortran)
 
-# Build for release or debug purposes?
-SET(CMAKE_BUILD_TYPE release)
-# Default flags for release and debug
-set(CMAKE_Fortran_FLAGS_RELEASE "-Wall")
-set(CMAKE_Fortran_FLAGS_DEBUG "-Wall -Werror")
+
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif(NOT CMAKE_BUILD_TYPE)
+
+if(CMAKE_Fortran_COMPILER_ID MATCHES GNU)
+    add_compile_options(
+        -Wall "$<$<CONFIG:Debug>:-Werror>"
+    )
+endif()
 
 # Build the executable
-add_executable(packmol 
-       cenmass.f90 
+add_executable(packmol
+       cenmass.f90
        gencan.f
-       pgencan.f90 
-       initial.f90 
-       title.f90 
-       setsizes.f90 
-       getinp.f90 
-       strlength.f90 
-       output.f90 
-       checkpoint.f90 
-       writesuccess.f90 
-       fparc.f90 
-       gparc.f90 
-       gwalls.f90 
-       comprest.f90 
-       comparegrad.f90 
-       packmol.f90 
-       polartocart.f90 
-       resetboxes.f90 
-       tobar.f90 
-       setijk.f90 
-       setibox.f90 
-       restmol.f90 
-       swaptype.f90 
-       swaptypemod.f90 
-       ahestetic.f90 
-       heuristics.f90 
-       flashsort.f90 
-       jacobi.f90 
-       random.f90 
-       sizes.f90 
-       usegencan.f90 
-       compute_data.f90 
-       flashmod.f90 
-       computef.f90 
-       computeg.f90 
+       pgencan.f90
+       initial.f90
+       title.f90
+       setsizes.f90
+       getinp.f90
+       strlength.f90
+       output.f90
+       checkpoint.f90
+       writesuccess.f90
+       fparc.f90
+       gparc.f90
+       gwalls.f90
+       comprest.f90
+       comparegrad.f90
+       packmol.f90
+       polartocart.f90
+       resetboxes.f90
+       tobar.f90
+       setijk.f90
+       setibox.f90
+       restmol.f90
+       swaptype.f90
+       swaptypemod.f90
+       ahestetic.f90
+       heuristics.f90
+       flashsort.f90
+       jacobi.f90
+       random.f90
+       sizes.f90
+       usegencan.f90
+       compute_data.f90
+       flashmod.f90
+       computef.f90
+       computeg.f90
        input.f90
 )
 
 # Installation directive
-install (TARGETS packmol DESTINATION bin)
+install(TARGETS packmol DESTINATION bin)


### PR DESCRIPTION
I have updated the CMake file.

The previous version explicitly set build type and compiler flags independent of the user's settings and available compiler. Also, the compiler flags were overridden such that the "Release" mode didn't contain any optimisation flags.

This version sets Release version only when nothing else is specified, and adds the compiler flags from the previous version only if the user is using the GNU compiler (gfortran). The CMake defaults are otherwise not touched.

With this change, packmol should work on any operating system and with any Fortran compiler straight out of the box.

I tested this version with GNU and Intel compilers.

The build instructions are the usual
```
cd packmol
mkdir build
cd build
cmake ..
make -j$(nproc)
```

_Thank you very much for this software - it has been most useful in my molecular dynamics work!_