### PR TITLE
CHARMM crd format enabled

### DIFF
--- a/getinp.f90
+++ b/getinp.f90
@@ -193,6 +193,7 @@ subroutine getinp()
              keyword(i,1) /= 'iprint1' .and. &
              keyword(i,1) /= 'iprint2' .and. &
              keyword(i,1) /= 'writecrd' .and. &
+             keyword(i,1) /= 'segid' .and. &
              keyword(i,1) /= 'chkgrad' ) then
       write(*,*) ' ERROR: Keyword not recognized: ', trim(keyword(i,1))
       stop
@@ -734,6 +735,7 @@ subroutine getinp()
       resnumbers(itype) = -1
       changechains(itype) = .false.
       chain(itype) = "#"
+      segid(itype) = ""
       do iline = 1, nlines
         if(iline.gt.linestrut(itype,1).and.&
              iline.lt.linestrut(itype,2)) then
@@ -746,8 +748,19 @@ subroutine getinp()
           if(keyword(iline,1).eq.'chain') then
             read(keyword(iline,2),*) chain(itype)
           end if
+          if(keyword(iline,1).eq.'segid') then
+            read(keyword(iline,2),*) segid(itype)
+          end if
         end if
       end do
+      if (crd) then
+         if (itype.gt.1 .and. segid(itype)=="") then
+            if (segid(itype-1) /= "")  then
+               write(*,*) ' Warning: Type of segid not defined for ', itype,'. Keeping it same as previous'
+            endif
+            segid(itype) = segid(itype-1)
+         endif
+      endif
       if ( resnumbers(itype) == -1 ) then
         write(*,*) ' Warning: Type of residue numbering not',&
                    ' set for structure ',itype
@@ -776,11 +789,16 @@ subroutine getinp()
     write(*,*) ' Number of molecules of type ', itype, ': ', nmols(itype)
     if(pdb.and.nmols(itype).gt.9999) then
       write(*,*) ' Warning: There will be more than 9999 molecules of type ',itype
-      write(*,*) '          Residue numbering is reset after 9999. '
+      if (.not. crd)  write(*,*) '          Residue numbering is reset after 9999. '
+      if (crd)  write(*,*) '          Residue numbering is reset after 9999 in pdb but not in crd. '
       if ( chain(itype) == "#" ) then
         write(*,*) ' Each set be will be assigned a different chain in the PDB output file. '
       end if
     end if
+    if(crd.and.nmols(itype).gt.99999999) then
+      write(*,*) ' Warning: There will be more than 99999999 molecules of type ',itype
+      write(*,*) '          Residue numbering is reset after 99999999 in crd. '
+    endif
   end do
 
   ! Checking if restart files will be used for each structure or for the whole system

--- a/input.f90
+++ b/input.f90
@@ -67,6 +67,7 @@ module input
 
   character(len=1), allocatable :: chain(:) ! (ntype)
   character(len=3), allocatable :: ele(:) ! (ntotat)
+  character(len=8), allocatable :: segid(:) ! (segment identifier)
   character(len=80), allocatable :: pdbfile(:) ! (ntype)
   character(len=200), allocatable :: name(:) ! (ntype)
   character(len=200), allocatable :: keyword(:,:) ! (nlines,maxkeywords)

--- a/output.f90
+++ b/output.f90
@@ -640,7 +640,7 @@ subroutine output(n,x)
               crdires = adjustl(crdires)
               crdresn = trim(adjustl(record(18:21)))
               crdsegi = crdresn
-              if (len(trim(adjustl(segid(i_not_fixed))))/=0) crdsegi = trim(adjustl(segid(i_not_fixed)))
+              if (len(trim(adjustl(segid(i_fixed))))/=0) crdsegi = trim(adjustl(segid(i_fixed)))
               atmname = adjustl(record(13:16))
               write(40,crd_format) i_ref_atom, iires,crdresn, atmname, &
                                    (xcart(icart,k), k = 1, 3), crdsegi,&

--- a/output.f90
+++ b/output.f90
@@ -15,7 +15,7 @@ subroutine output(n,x)
   implicit none
   integer :: n, k, i, ilugan, ilubar, itype, imol, idatom,&
              irest, iimol, ichain, iatom, irec, ilres, ifres,&
-             iires, strlength, irescount,&
+             iires, ciires, strlength, irescount,&
              icart, i_ref_atom, ioerr
   integer :: nr, nres, imark  
   integer :: i_fixed, i_not_fixed
@@ -34,6 +34,7 @@ subroutine output(n,x)
   character(len=64) :: title
   character(len=80) :: pdb_atom_line, pdb_hetatm_line, tinker_atom_line, format_line,&
                        pdb_atom_line_hex, pdb_hetatm_line_hex, crd_format
+  character(len=8) :: crdires,crdresn,crdsegi,atmname
   character(len=200) :: record
 
   ! Job title
@@ -362,6 +363,11 @@ subroutine output(n,x)
     open(30,file=xyzout,status='unknown') 
     if ( crd ) then
       open(40,file=crdfile,status='unknown')
+      write(40,'("* TITLE ", a64,/&
+                &"* Packmol generated CHARMM CRD File",/&
+                &"* Home-Page:",/&
+                &"* http://www.ime.unicamp.br/~martinez/packmol",/&
+                &"* ")') title
       write(40,'(i10,2x,a)') ntotat,'EXT'
     end if
  
@@ -485,14 +491,19 @@ subroutine output(n,x)
             if ( ioerr /= 0 ) imark = 1
             if(resnumbers(i_not_fixed).eq.0) then
               iires = mod(imol,9999)
+              ciires = mod(imol,99999999)
             else if(resnumbers(i_not_fixed).eq.1) then
               iires = imark
+              ciires = imark
             else if(resnumbers(i_not_fixed).eq.2) then
               iires = mod(imark-ifres+irescount,9999)
+              ciires = mod(imark-ifres+irescount,99999999)
             else if(resnumbers(i_not_fixed).eq.3) then
               iires = mod(iimol,9999)
+              ciires = mod(iimol,99999999)
             end if
             if(iires.eq.0) iires = 9999
+            if(ciires.eq.0) ciires = 99999999
 
             ! Writing output line
 
@@ -517,10 +528,15 @@ subroutine output(n,x)
             end if
 
             if ( crd ) then
-              write(40,crd_format) i_ref_atom, iires, record(18:20), &
-                                   record(13:16),&
-                                   (xcart(icart,k), k = 1, 3), "X",&
-                                   record(13:16), 0.
+              write(crdires,'(I8)') ciires 
+              crdires = adjustl(crdires)
+              crdresn = trim(adjustl(record(18:21)))
+              crdsegi = crdresn
+              if (len(trim(adjustl(segid(i_not_fixed))))/=0) crdsegi = trim(adjustl(segid(i_not_fixed)))
+              atmname = adjustl(record(13:16))
+              write(40,crd_format) i_ref_atom, ciires,crdresn, atmname, &
+                                   (xcart(icart,k), k = 1, 3), crdsegi,&
+                                   crdires, 0.
             end if
 
           end do
@@ -585,12 +601,16 @@ subroutine output(n,x)
           read(record(23:26),*) imark
           if(resnumbers(i_fixed).eq.0) then
             iires = 1
+            ciires = 1
           else if(resnumbers(i_fixed).eq.1) then
             iires = imark
+            ciires = imark
           else if(resnumbers(i_fixed).eq.2) then
             iires = mod(imark-ifres+irescount,9999) 
+            ciires = mod(imark-ifres+irescount,99999999) 
           else if(resnumbers(i_fixed).eq.3) then
             iires = mod(iimol,9999)
+            ciires = mod(iimol,99999999)
           end if
 
           if ( chain(i_fixed) == "#" ) then
@@ -616,10 +636,15 @@ subroutine output(n,x)
           end if
 
           if ( crd ) then
-            write(40,crd_format) i_ref_atom, iires, record(18:20), &
-                                 record(13:16),&
-                                 (coor(idatom,k), k = 1, 3), "X",&
-                                 record(13:16), 0.
+              write(crdires,'(I8)') ciires 
+              crdires = adjustl(crdires)
+              crdresn = trim(adjustl(record(18:21)))
+              crdsegi = crdresn
+              if (len(trim(adjustl(segid(i_not_fixed))))/=0) crdsegi = trim(adjustl(segid(i_not_fixed)))
+              atmname = adjustl(record(13:16))
+              write(40,crd_format) i_ref_atom, iires,crdresn, atmname, &
+                                   (xcart(icart,k), k = 1, 3), crdsegi,&
+                                   crdires, 0.
           end if
 
         end do

--- a/setsizes.f90
+++ b/setsizes.f90
@@ -341,7 +341,8 @@ subroutine setsizes()
 
   allocate(irestline(maxrest),linestrut(ntype,2),resnumbers(ntype),&
            input_itype(ntype),changechains(ntype),chain(ntype),&
-           fixedoninput(ntype),pdbfile(ntype),name(ntype))
+           fixedoninput(ntype),pdbfile(ntype),name(ntype),&
+           segid(ntype))
 
   ! Allocate vectors for flashsort
 


### PR DESCRIPTION
I have performed all the required changes to create crd identical to CHARMM format.
The entries read in "record" are left aligned before writing crd format.

A new keyword segid is also added to be able to modify segment name written in third last column.
If no segid is specified, it remains same as resname read from file.
If segid is specified, it is kept the same for following "itypes" until another segid is encountered. 